### PR TITLE
#3 修改错误的全连接配置,配置当中多一个:,会导致 angel 当中的如 deepFM 基于默认配置的网络,在构建时出现参数解析错误

### DIFF
--- a/src/main/scala/com/tencent/angel/mlcore/conf/MLCoreConf.scala
+++ b/src/main/scala/com/tencent/angel/mlcore/conf/MLCoreConf.scala
@@ -175,7 +175,7 @@ object MLCoreConf {
 
   // (MLP) Layer params
   val ML_FCLAYER_PARAMS = "ml.fclayer.params"
-  val DEFAULT_ML_FCLAYER_PARAMS = "100:relu:momentum|100::relu:momentum|1:identity:momentum"
+  val DEFAULT_ML_FCLAYER_PARAMS = "100:relu:momentum|100:relu:momentum|1:identity:momentum"
 
   val ML_ROBUSTREGRESSION_LOSS_DELTA = "ml.robustregression.loss.delta"
   val DEFAULT_ML_ROBUSTREGRESSION_LOSS_DELTA = 1.0


### PR DESCRIPTION
配置问题, 该配置会导致 angel-ps-mllib当中的项目 deep 不能解析全连接的默认配置参数

override def buildNetwork(): this.type = {
    val inputOptName: String = conf.get(MLCoreConf.ML_INPUTLAYER_OPTIMIZER, MLCoreConf.DEFAULT_ML_INPUTLAYER_OPTIMIZER)
    val wide = new SimpleInputLayer("input", 1, new Identity(), optProvider.getOptimizer(inputOptName))

    val embeddingOptName: String = conf.get(MLCoreConf.ML_EMBEDDING_OPTIMIZER, MLCoreConf.DEFAULT_ML_EMBEDDING_OPTIMIZER)
    val embedding = new Embedding("embedding", numFields * numFactors, numFactors, optProvider.getOptimizer(embeddingOptName))

    val innerSumCross = new BiInnerSumCross("innerSumPooling", embedding)

    // outputDim:transFunc:optimizer
    var fcLayer: Layer = innerSumCross
    val fclayerParams = conf.get(MLCoreConf.ML_FCLAYER_PARAMS, MLCoreConf.DEFAULT_ML_FCLAYER_PARAMS)
   //这里会出现参数解析问题,源代码本身存在配置参数 split  bug angel 项目也提交了 issure
  //源代码问题fclayerParams.split("|"),为添加转移
    fclayerParams.split("\\|").zipWithIndex.foreach{ case (params: String, idx: Int) =>
      val name = s"fclayer_$idx"
      params.split(":") match {
        case Array(outputDim: String, transFunc: String, optimizer: String) =>
          fcLayer = new FCLayer(name, outputDim.toInt, fcLayer,
            TransFunc.fromString(transFunc), optProvider.getOptimizer(optimizer))
        case Array(outputDim: String, transFunc: String) =>
          fcLayer = new FCLayer(name, outputDim.toInt, fcLayer,
            TransFunc.fromString(transFunc), optProvider.getDefaultOptimizer())
        case Array(outputDim: String) =>
          fcLayer = new FCLayer(name, outputDim.toInt, fcLayer,
            TransFunc.defaultTransFunc(), optProvider.getDefaultOptimizer())
      }